### PR TITLE
Fix SSE backend implementation

### DIFF
--- a/backend/middleware/sse.js
+++ b/backend/middleware/sse.js
@@ -1,3 +1,41 @@
-// middleware/sse.js
-const SSE = require('express-sse')
-module.exports = new SSE()
+class SSEManager {
+  constructor() {
+    this.clients = new Map();
+  }
+
+  init(req, res, clientId) {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive'
+    });
+    const id = clientId || req.userId || Date.now().toString();
+    this.register(id, res);
+    req.on('close', () => {
+      this.unregister(id);
+    });
+  }
+
+  register(id, res) {
+    this.clients.set(id, res);
+  }
+
+  unregister(id) {
+    const res = this.clients.get(id);
+    if (res) {
+      res.end();
+      this.clients.delete(id);
+    }
+  }
+
+  broadcast(data) {
+    const payload = `data: ${JSON.stringify(data)}\n\n`;
+    for (const res of this.clients.values()) {
+      try {
+        res.write(payload);
+      } catch {}
+    }
+  }
+}
+
+module.exports = new SSEManager();

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,6 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
-        "express-sse": "^1.0.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.16.0",
@@ -1038,15 +1037,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express-sse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/express-sse/-/express-sse-1.0.0.tgz",
-      "integrity": "sha512-ny3nCXjrWwQki8edZe0DwuXjLbw0ga3pc0CZX19VOB0GKuUnlIH2fqPBwTJcGHZPtmjJ2EVNPVeCgORpX6Nsrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/fetch-blob": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,6 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "express-sse": "^1.0.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.16.0",


### PR DESCRIPTION
## Summary
- replace express-sse with a small custom SSE manager
- clean `express-sse` from dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688246d15ef483328f3132909f0df704